### PR TITLE
fix(dependencies): update requirements and OCPP compatibility

### DIFF
--- a/ev-charge-point-simulator/requirements.txt
+++ b/ev-charge-point-simulator/requirements.txt
@@ -1,2 +1,2 @@
-ocpp
-websockets
+ocpp==2.0.0
+websockets==13.0

--- a/ev-charge-point-simulator/simulate.py
+++ b/ev-charge-point-simulator/simulate.py
@@ -5,15 +5,14 @@ import websockets
 
 from ocpp.v201 import call
 from ocpp.v201 import ChargePoint as cp
-from ocpp.v201.enums import RegistrationStatusType
-
+from ocpp.v201.enums import RegistrationStatusEnumType as RegistrationStatusType
 
 logging.basicConfig(level=logging.INFO)
 
 
 class ChargePointSimlator(cp):
     async def send_boot_notification(self):
-        request = call.BootNotificationPayload(
+        request = call.BootNotification(
             charging_station={
                 "serial_number": arguments["cp_serial"],
                 "model": arguments["cp_model"],
@@ -43,7 +42,7 @@ class ChargePointSimlator(cp):
 
     async def send_heartbeats(self, arguments):
         while True:
-            request = call.HeartbeatPayload()
+            request = call.Heartbeat()
             await self.call(request)
             await asyncio.sleep(arguments["heartbeat_interval"])
 

--- a/src/ocpp-gateway-container/requirements.txt
+++ b/src/ocpp-gateway-container/requirements.txt
@@ -1,4 +1,4 @@
 boto3
-websockets
+websockets==13.0
 paho-mqtt==1.6.1
 asyncio-mqtt

--- a/src/ocpp-gateway-container/requirements.txt
+++ b/src/ocpp-gateway-container/requirements.txt
@@ -1,4 +1,4 @@
-boto3
+boto3==1.37.3
 websockets==13.0
 paho-mqtt==1.6.1
-asyncio-mqtt
+asyncio-mqtt==0.16.2


### PR DESCRIPTION
- feat: specify exact package versions in requirements.txt per AWS MWAA best practices
- fix: restrict websockets to <14.0 due to OCPP v2.0.0 compatibility
- refactor: rename RegistrationStatusType to RegistrationStatusEnumType
- refactor: replace deprecated BootNotificationPayload with BootNotification
- refactor: replace deprecated HeartbeatPayload with Heartbeat()

Ref:
https://aws.amazon.com/blogs/big-data/amazon-mwaa-best-practices-for-managing-python-dependencies/ https://github.com/mobilityhouse/ocpp/issues/709

*Issue #, https://github.com/aws-solutions-library-samples/guidance-for-modernizing-electric-vehicle-charging-on-aws/issues/153

*Description of changes:*

I have identified and fixed the root cause of the WebSocket Error 1011. The issue stems from multiple compatibility and dependency management challenges:

1. OCPP Protocol Compatibility Issues:

- The websockets library versions >=14.0 introduce breaking changes that affect OCPP v2.0.0 implementations
- Recent versions of the OCPP library deprecated several payload types that we were using

2. Dependency Management Problems:

- Unpinned dependencies in requirements.txt leading to potentially incompatible package versions being installed
- Usage of deprecated OCPP payload types causing internal server errors during WebSocket handshake
- Misalignment between python requirements and loose dependency specifications
- The solution involves:

a) Package Version Management:

- Implemented strict version pinning following AWS best practices
- Specifically restricted websockets==13.0 to maintain OCPP compatibility
- Updated some dependencies to their last known compatible versions

b) OCPP Implementation Updates:

- Replaced RegistrationStatusType with RegistrationStatusEnumType
- Updated BootNotificationPayload to BootNotification
- Migrated from HeartbeatPayload to Heartbeat
- Ensured all OCPP message types align with current specifications

c) Code Modernization:

- Removed deprecated API calls
- Updated payload structures to match current OCPP standards

References:

- AWS MWAA Best Practices: https://aws.amazon.com/blogs/big-data/amazon-mwaa-best-practices-for-managing-python-dependencies/
- OCPP Issue Thread: https://github.com/mobilityhouse/ocpp/issues/709

------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
